### PR TITLE
More definitions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-Compat 0.9.4
+Compat 0.13.0

--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -4,9 +4,9 @@ module Nulls
 
 using Compat
 importall Base.Operators
-import Compat: xor
+import Compat: xor, iszero
 
-export null, ?
+export null, Null, ?
 
 if VERSION < v"0.6.0-dev.2746"
     immutable Null end
@@ -28,6 +28,11 @@ Base.size(x::Null, i::Integer) = i < 1 ? throw(BoundsError()) : 1
 Base.ndims(x::Null) = 0
 Base.getindex(x::Null, i) = i == 1 ? null : throw(BoundsError())
 
+# Iteration rules modeled after that for numbers
+Base.start(::Null) = false
+Base.next(::Null, ::Bool) = (null, true)
+Base.done(::Null, b::Bool) = b
+
 Base.promote_rule{T}(::Type{T}, ::Type{Null}) = Union{T, Null}
 
 # Comparison operators
@@ -42,19 +47,19 @@ Base.isless(::Null, b) = false
 Base.isless(a, ::Null) = true
 
 # Unary operators/functions
-for f in (:(+), :(-), :(*), :(/),
+for f in (:(+), :(-), :(Base.identity),
           :(Base.abs), :(Base.abs2), :(Base.sign),
           :(Base.acos), :(Base.acosh), :(Base.asin), :(Base.asinh), :(Base.atan), :(Base.atanh),
           :(Base.sin), :(Base.sinh), :(Base.cos), :(Base.cosh), :(Base.tan), :(Base.tanh),
           :(Base.exp), :(Base.exp2), :(Base.expm1), :(Base.log), :(Base.log10), :(Base.log1p),
           :(Base.log2), :(Base.exponent), :(Base.sqrt), :(Base.gamma), :(Base.lgamma),
-          :(Base.ceil), :(Base.floor), :(Base.round), :(Base.trunc)
-         )
+          :(Base.ceil), :(Base.floor), :(Base.round), :(Base.trunc))
     @eval $(f)(d::Null) = null
 end
 
 for f in (:(Base.iseven), :(Base.ispow2), :(Base.isfinite), :(Base.isinf), :(Base.isodd),
-          :(Base.isinteger), :(Base.isreal), :(Base.isempty))
+          :(Base.isinteger), :(Base.isreal), :(Base.isimag), :(Base.isnan), :(Base.isempty),
+          :(Compat.iszero))
     @eval $(f)(d::Null) = false
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,13 @@ using Compat
                                   conj, cos, cosh, tan, tanh,
                                   ceil, floor, round, trunc,
                                   exp, exp2, expm1, log, log10, log1p, log2,
-                                  exponent, sqrt, gamma, lgamma]
+                                  exponent, sqrt, gamma, lgamma,
+                                  identity]
+
+    const boolean_functions = [iseven, isodd, ispow2,
+                               isfinite, isinf, isnan, Compat.iszero,
+                               isinteger, isreal, isimag,
+                               isempty]
 
     # All unary operators return null when evaluating null
     for f in [+, -]
@@ -22,6 +28,11 @@ using Compat
     # All elementary functions return null when evaluating null
     for f in elementary_functions
         @test isnull(f(null))
+    end
+
+    # All boolean functions return false when evaluating null
+    for f in boolean_functions
+        @test !f(null)
     end
 
     # Comparison operators


### PR DESCRIPTION
A wee bit o' PR scope creep. I was just going to add `identity`, then suddenly...

* Export `Null` to make it easier for other people to define methods
* Add iteration functions `start`, `next`, and `done`
* Remove unary `*` and `/` (DataArrays had this and it makes no sense)
* Add `identity`, `isnan`, `iszero`
* Add more tests