### PR TITLE
Add convert(::Type{Null}, ::Null) method

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -34,6 +34,7 @@ Base.done(::Null, b::Bool) = b
 
 Base.promote_rule{T}(::Type{T}, ::Type{Null}) = Union{T, Null}
 Base.convert(::Type{Null}, x) = null
+Base.convert(::Type{Null}, ::Null) = null
 
 # Comparison operators
 ==(::Null, ::Null) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,5 +107,6 @@ using Compat
     @test collect(Nulls.skip([1, 2, null, 4])) == [1, 2, 4]
     @test collect(Nulls.skip(1:4, 3)) == [1, 2, 4]
 
-    @test isnull(convert(Null, 1))
+    @test convert(Null, 1) === null
+    @test convert(Null, null) === null
 end


### PR DESCRIPTION
Fixes an ambiguity. Also make an existing test stricter.

@quinnj What do you need `convert(::Type{Null}, x)` for? Looks like a possibly dangerous method.