### PR TITLE
Disallow conversion to null

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -45,9 +45,6 @@ Base.next(::Null, ::Bool) = (null, true)
 Base.done(::Null, b::Bool) = b
 
 Base.promote_rule{T}(::Type{T}, ::Type{Null}) = Union{T, Null}
-Null(x) = null
-Base.convert(::Type{Null}, ::Null) = null
-Base.convert{T}(::Type{Union{T, Null}}, x) = convert(T, x)
 
 # Comparison operators
 ==(::Null, ::Null) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,9 +107,6 @@ using Compat
     @test collect(Nulls.skip([1, 2, null, 4])) == [1, 2, 4]
     @test collect(Nulls.skip(1:4, 3)) == [1, 2, 4]
 
-    @test Null(1) === null
-    @test convert(Null, null) === null
-
     @test Nulls.T(?Int) == Int
 
     @test nulls(1) == [null]


### PR DESCRIPTION
This can be dangerous since it allows creating missing values from valid ones,
which can happen e.g. when assigning to an `Array{Null}` which was expected to be
`Array{Union{T, Null}}`.

As discussed in https://github.com/JuliaData/Nulls.jl/pull/8.