### PR TITLE
Change semantics of <(::Any, ::Null) to match those of NaN

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -55,7 +55,7 @@ Base.convert{T}(::Type{Union{T, Null}}, x) = convert(T, x)
 ==(a, ::Null) = false
 <(::Null, ::Null) = false
 <(::Null, b) = false
-<(a, ::Null) = true
+<(a, ::Null) = false
 Base.isless(::Null, ::Null) = false
 Base.isless(::Null, b) = false
 Base.isless(a, ::Null) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ using Compat
     @test null != 1
     @test !(null < null)
     @test !(null < 1)
-    @test 1 < null
+    @test !(1 < null)
     @test !isless(null, null)
     @test !isless(null, 1)
     @test isless(1, null)


### PR DESCRIPTION
This also matches the behavior of null in C#, and it's generally more useful,
e.g. when selecting observations based on a condition. isless() still
corresponds to a total order.

Cc: @davidanthoff