### PR TITLE
Add back convert(::Type{Union{T, Null}}, ::Any) method

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -45,6 +45,7 @@ Base.next(::Null, ::Bool) = (null, true)
 Base.done(::Null, b::Bool) = b
 
 Base.promote_rule{T}(::Type{T}, ::Type{Null}) = Union{T, Null}
+Base.convert{T}(::Type{Union{T, Null}}, x) = convert(T, x)
 
 # Comparison operators
 ==(::Null, ::Null) = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,6 +107,16 @@ using Compat
     @test collect(Nulls.skip([1, 2, null, 4])) == [1, 2, 4]
     @test collect(Nulls.skip(1:4, 3)) == [1, 2, 4]
 
+    x = convert(Vector{?Int}, [1.0, null])
+    @test isa(x, Vector{?Int})
+    @test x == [1, null]
+    x = convert(Vector{?Int}, [1.0])
+    @test isa(x, Vector{?Int})
+    @test x == [1]
+    x = convert(Vector{?Int}, [null])
+    @test isa(x, Vector{?Int})
+    @test x == [null]
+
     @test Nulls.T(?Int) == Int
 
     @test nulls(1) == [null]


### PR DESCRIPTION
This method is required for conversions such as convert(Vector{?Int}, [1.0, null]).