### PR TITLE
Remove ==(::Any, ::Null)

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -49,8 +49,6 @@ Base.convert{T}(::Type{Union{T, Null}}, x) = convert(T, x)
 
 # Comparison operators
 ==(::Null, ::Null) = true
-==(::Null, b) = false
-==(a, ::Null) = false
 <(::Null, ::Null) = false
 <(::Null, b) = false
 <(a, ::Null) = false


### PR DESCRIPTION
These two definitions are not required since the fallback on === gives the
same result, yet they generate lots of ambiguities.