### PR TITLE
Fix <= on Julia 0.6

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -60,6 +60,11 @@ Base.convert{T}(::Type{Union{T, Null}}, x) = convert(T, x)
 Base.isless(::Null, ::Null) = false
 Base.isless(::Null, b) = false
 Base.isless(a, ::Null) = true
+if VERSION < v"0.7.0-DEV.300"
+    <=(::Null, ::Null) = true
+    <=(::Null, b) = false
+    <=(a, ::Null) = false
+end
 
 # Unary operators/functions
 for f in (:(+), :(-), :(Base.identity),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,9 @@ using Compat
     @test !(null < null)
     @test !(null < 1)
     @test !(1 < null)
+    @test null <= null
+    @test !(null <= 1)
+    @test !(1 <= null)
     @test !isless(null, null)
     @test !isless(null, 1)
     @test isless(1, null)


### PR DESCRIPTION
`<=(x, y)` is defined as `!(y < x)` on Julia 0.6, which is `true`. On Julia 0.7,
the definition has been changed to the more correct `(x < y) | (x == y)`.
`>=` is defined based on `<=`.