### PR TITLE
Remove custom show() method

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -10,7 +10,6 @@ struct Null end
 const null = Null()
 
 Base.show(io::IO, x::Null) = print(io, "null")
-Base.show(io::IO, ::Type{Union{T, Null}}) where {T} = print(io, "?$T")
 Base.show(io::IO, ::Type{Any}) = print(io, "Any")
 
 T(::Type{Union{T1, Null}}) where {T1} = T1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,5 +131,5 @@ using Base.Test, Nulls
     @test Nulls.T(Any) == Any
     io = IOBuffer()
     show(io, Union{Float64, Null})
-    @test String(take!(io)) == "?Float64"
+    @test String(take!(io)) == "Union{Nulls.Null, Float64}"
 end


### PR DESCRIPTION
It's incorrect now that the `?T` syntax has been removed.