### PR TITLE
Remove show method already handled by Base.show

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -10,7 +10,6 @@ struct Null end
 const null = Null()
 
 Base.show(io::IO, x::Null) = print(io, "null")
-Base.show(io::IO, ::Type{Any}) = print(io, "Any")
 
 T(::Type{Union{T1, Null}}) where {T1} = T1
 T(::Type{T1}) where {T1} = T1


### PR DESCRIPTION
I don't think we need this, seems to be handled fine by Base.show.

If this passes I'll merge and tag a new 0.0.6 release, which we will need to set as the new version minimum for DataTables and CategoricalArrays which will stop/have stopped using the `?T` syntax present in release 0.0.5