### PR TITLE
Add coalesce() function

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -96,4 +96,41 @@ replace(itr, a, b) = (ifelse(v == a, b, v) for v in itr)
 replace(itr, b) = replace(itr, null, b)
 skip(itr, a=null) = (v for v in itr if v != a)
 
+"""
+    coalesce(x, y...)
+
+Return the first non-`null` value in the arguments, or `null` if all arguments are `null`.
+
+In its broadcasted form, this function can be used to replace all null values
+in an array with a given value (see examples).
+
+# Examples
+
+```jldoctest
+julia> coalesce(null, 1)
+1
+
+julia> coalesce(1, null)
+1
+
+julia> coalesce(null, null)
+null
+
+julia> coalesce.([null, 1, null], 0)
+3-element Array{$Int,1}:
+ 0
+ 1
+ 0
+
+julia> coalesce.([null, 1, null], [0, 10, 5])
+3-element Array{$Int,1}:
+ 0
+ 1
+ 5
+
+```
+"""
+coalesce(x) = x
+coalesce(x, y...) = ifelse(x !== null, x, coalesce(y...))
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,17 @@ using Base.Test, Nulls
     @test collect(Nulls.skip([1, 2, null, 4])) == [1, 2, 4]
     @test collect(Nulls.skip(1:4, 3)) == [1, 2, 4]
 
+    @test Nulls.coalesce(null, 1) === 1
+    @test Nulls.coalesce(1, null) === 1
+    @test Nulls.coalesce(null, null) === null
+    @test Nulls.coalesce.([null, 1, null], 0) == [0, 1, 0]
+    @test Nulls.coalesce.([null, 1, null], 0) isa Vector{Int}
+    @test Nulls.coalesce.([null, 1, null], [0, 10, 5]) == [0, 1, 5]
+    @test Nulls.coalesce.([null, 1, null], [0, 10, 5]) isa Vector{Int}
+    @test Nulls.coalesce.([null, 1, null], [0, null, null]) == [0, 1, null]
+    # Fails in Julia 0.6 and 0.7.0-DEV.1556
+    @test_broken Nulls.coalesce.([null, 1, null], [0, null, null]) isa Vector{Union{Null, Int}}
+
     x = convert(Vector{Union{Int, Null}}, [1.0, null])
     @test isa(x, Vector{Union{Int, Null}})
     @test x == [1, null]


### PR DESCRIPTION
Small helper function which is useful either to take the first non-missing
value, or to replace missing values with a given value (when passing a value known
not to be missing). Also usable in its broadcasted form, where a non-null
scalar argument will be automatically used in place of all nulls.
Inspired by the equivalent SQL and dplyr function.

Currently, broadcast returns a `Vector{Any}` rather than the more efficient
`Vector{Union{Null, T}}` when the result contains nulls. This will have to
be improved in Base.

The function is not exported (like `replace()` and `skip()`), but it could be
at some point since its name is unlikely to conflict with other packages.