### PR TITLE
Remove too general replace() and skip() methods

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -92,8 +92,7 @@ xor(::Null, ::Null) = null
 xor(a::Null, b::Bool) = null
 xor(b::Bool, a::Null) = null
 
-replace(itr, a, b) = (ifelse(v == a, b, v) for v in itr)
-replace(itr, b) = replace(itr, null, b)
-skip(itr, a=null) = (v for v in itr if v != a)
+replace(itr, x) = (ifelse(v !== null, v, x) for v in itr)
+skip(itr) = (v for v in itr if v !== null)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,10 +104,8 @@ using Base.Test, Nulls
     @test done(null, true)
     @test !done(null, false)
 
-    @test collect(Nulls.replace(1:4, 3, 0)) == [1, 2, 0, 4]
     @test collect(Nulls.replace([1, 2, null, 4], 3)) == collect(1:4)
     @test collect(Nulls.skip([1, 2, null, 4])) == [1, 2, 4]
-    @test collect(Nulls.skip(1:4, 3)) == [1, 2, 4]
 
     x = convert(Vector{Union{Int, Null}}, [1.0, null])
     @test isa(x, Vector{Union{Int, Null}})


### PR DESCRIPTION
Since these are supposed to be called via Nulls.replace() and Nulls.skip(),
there is not point in accepting an argument to choose which element to replace.
This allows using === null, which can help the compiler optimize out some checks.

--------

Better do this early before people rely on the package. We can always make the methods more general again later if we want.

We could use `isnull(x)` rather than `x === null` to allow extending this design, but that may be OK for now.