### PR TITLE
Change boolean functions to return null when passed null

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -66,14 +66,11 @@ for f in (:(!), :(+), :(-), :(Base.identity), :(Base.zero),
           :(Base.sin), :(Base.sinh), :(Base.cos), :(Base.cosh), :(Base.tan), :(Base.tanh),
           :(Base.exp), :(Base.exp2), :(Base.expm1), :(Base.log), :(Base.log10), :(Base.log1p),
           :(Base.log2), :(Base.exponent), :(Base.sqrt), :(Base.gamma), :(Base.lgamma),
-          :(Base.ceil), :(Base.floor), :(Base.round), :(Base.trunc))
-    @eval $(f)(d::Null) = null
-end
-
-for f in (:(Base.iseven), :(Base.ispow2), :(Base.isfinite), :(Base.isinf), :(Base.isodd),
+          :(Base.ceil), :(Base.floor), :(Base.round), :(Base.trunc),
+          :(Base.iseven), :(Base.ispow2), :(Base.isfinite), :(Base.isinf), :(Base.isodd),
           :(Base.isinteger), :(Base.isreal), :(Base.isimag), :(Base.isnan), :(Base.isempty),
           :(Base.iszero))
-    @eval $(f)(d::Null) = false
+    @eval $(f)(d::Null) = null
 end
 
 Base.zero(::Type{Union{T, Null}}) where {T} = zero(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,12 +12,11 @@ using Base.Test, Nulls
                             ceil, floor, round, trunc,
                             exp, exp2, expm1, log, log10, log1p, log2,
                             exponent, sqrt, gamma, lgamma,
-                            identity, zero]
-
-    boolean_functions = [iseven, isodd, ispow2,
-                         isfinite, isinf, isnan, iszero,
-                         isinteger, isreal, isimag,
-                         isempty]
+                            identity, zero,
+                            iseven, isodd, ispow2,
+                            isfinite, isinf, isnan, iszero,
+                            isinteger, isreal, isimag,
+                            isempty]
 
     # All unary operators return null when evaluating null
     for f in [!, +, -]
@@ -27,11 +26,6 @@ using Base.Test, Nulls
     # All elementary functions return null when evaluating null
     for f in elementary_functions
         @test isnull(f(null))
-    end
-
-    # All boolean functions return false when evaluating null
-    for f in boolean_functions
-        @test !f(null)
     end
 
     @test zero(Union{Int, Null}) === 0


### PR DESCRIPTION
These were inconsistent with the rule of treating null as an unknown value,
propagating null everywhere (except when the result is known despite the
presence of nulls, as with boolean operators implementing 3VL).