### PR TITLE
Remove implementation of iteration protocol

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -17,21 +17,10 @@ T(::Type{Any}) = Any
 
 Base.isnull(v::Null) = true
 
-Base.length(x::Null) = 1
-Base.size(x::Null) = ()
-Base.size(x::Null, i::Integer) = i < 1 ? throw(BoundsError()) : 1
-Base.ndims(x::Null) = 0
-Base.getindex(x::Null, i) = i == 1 ? null : throw(BoundsError())
-
 # vector constructors
 nulls(dims...) = fill(null, dims)
 nulls(::Type{T}, dims...) where {T >: Null} = fill!(Array{T}(dims), null)
 nulls(::Type{T}, dims...) where {T} = fill!(Array{Union{T, Null}}(dims), null)
-
-# Iteration rules modeled after that for numbers
-Base.start(::Null) = false
-Base.next(::Null, ::Bool) = (null, true)
-Base.done(::Null, b::Bool) = b
 
 Base.promote_rule(::Type{T}, ::Type{Null}) where {T} = Union{T, Null}
 Base.convert(::Type{Union{T, Null}}, x) where {T} = convert(T, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,31 +85,7 @@ using Base.Test, Nulls
     @test isnull(xor(null, 1))
     @test isnull(xor(1, null))
 
-    @test length(null) == 1
-    @test size(null) == ()
-    @test size(null, 1) == 1
-    @test_throws BoundsError size(null, 0)
-    @test ndims(null) == 0
-    @test null[1] === null
-    @test_throws BoundsError null[2]
-
-    @test eltype([1, 2, null]) == Union{Int, Null}
-
     @test sprint(show, null) == "null"
-
-    # Iteration over scalars works as with numbers
-    for i in null
-        @test isnull(i)
-    end
-    @test !start(null)
-    let (a, b) = next(null, true)
-        @test isnull(a) && b
-    end
-    let (a, b) = next(null, false)
-        @test isnull(a) && b
-    end
-    @test done(null, true)
-    @test !done(null, false)
 
     @test collect(Nulls.replace([1, 2, null, 4], 3)) == collect(1:4)
     @test collect(Nulls.skip([1, 2, null, 4])) == [1, 2, 4]


### PR DESCRIPTION
It is designed to make null behave like numbers, but it is incorrect if null is mixed e.g. with strings.

Fixes https://github.com/JuliaData/Nulls.jl/issues/39.