### PR TITLE
Restrict zero function types

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -67,7 +67,7 @@ for f in (:(!), :(+), :(-), :(Base.identity), :(Base.zero),
     @eval $(f)(d::Null) = null
 end
 
-Base.zero(::Type{Union{T, Null}}) where {T} = zero(T)
+Base.zero(::Type{Union{T, Null}}) where {T <: Number} = zero(T)
 
 # Binary operators/functions
 for f in (:(+), :(-), :(*), :(/), :(^),


### PR DESCRIPTION
Base only provides `zero(::Type{T}) where T<:Number`, not `zero(::Type{T}) where T`, and our method results in StackOverflows when called with `Any` when it should return an error. See https://github.com/JuliaData/DataFrames.jl/issues/1251