### PR TITLE
Add levels() function

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -4,7 +4,7 @@ module Nulls
 import Base: *, <, ==, !=, <=, !, +, -, ^, /, &, |, xor
 using Compat: AbstractRange
 
-export null, nulls, Null
+export null, nulls, Null, levels
 
 struct Null end
 
@@ -149,6 +149,25 @@ julia> coalesce.([null, 1, null], [0, 10, 5])
 """
 coalesce(x) = x
 coalesce(x, y...) = ifelse(x !== null, x, coalesce(y...))
+
+"""
+    levels(x)
+
+Return a vector of unique values which occur or could occur in collection `x`,
+omitting `null` even if present. Values are returned in the preferred order
+for the collection, with the result of [`sort`](@ref) as a default.
+
+Contrary to [`unique`](@ref), this function may return values which do not
+actually occur in the data, and does not preserve their order of appearance in `x`.
+"""
+function levels(x)
+    T = Nulls.T(eltype(x))
+    levs = convert(AbstractArray{T}, filter!(!isnull, unique(x)))
+    if method_exists(isless, Tuple{T, T})
+        try; sort!(levs); end
+    end
+    levs
+end
 
 # AbstractArray{>:Null} functions
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,6 +131,17 @@ using Base.Test, Nulls
     # Fails in Julia 0.6 and 0.7.0-DEV.1556
     @test_broken Nulls.coalesce.([null, 1, null], [0, null, null]) isa Vector{Union{Null, Int}}
 
+    @test levels(1:1) == levels([1]) == levels([1, null]) == levels([null, 1]) == [1]
+    @test levels(2:-1:1) == levels([2, 1]) == levels([2, null, 1]) == [1, 2]
+    @test levels([null, "a", "c", null, "b"]) == ["a", "b", "c"]
+    @test levels([Complex(0, 1), Complex(1, 0), null]) == [Complex(0, 1), Complex(1, 0)]
+    @test levels(sparse([0 3 2])) == [0, 2, 3]
+    @test typeof(levels([1])) === typeof(levels([1, null])) === Vector{Int}
+    @test typeof(levels(["a"])) === typeof(levels(["a", null])) === Vector{String}
+    @test typeof(levels(sparse([1]))) === Vector{Int}
+    @test isempty(levels([null]))
+    @test isempty(levels([]))
+
     x = convert(Vector{Union{Int, Null}}, [1.0, null])
     @test isa(x, Vector{Union{Int, Null}})
     @test isequal(x, [1, null])


### PR DESCRIPTION
Nulls is a natural home for this method since it skips null values,
and it needs to be defined in an essential package so that both DataArrays
and CategoricalArrays can override it, and other packages use it without
conflicts nor heavy dependencies.