### PR TITLE
Add Nulls.T(Null) == Union{}

### DIFF
--- a/src/Nulls.jl
+++ b/src/Nulls.jl
@@ -13,6 +13,7 @@ const null = Null()
 Base.show(io::IO, x::Null) = print(io, "null")
 
 T(::Type{Union{T1, Null}}) where {T1} = T1
+T(::Type{Null}) = Union{}
 T(::Type{T1}) where {T1} = T1
 T(::Type{Any}) = Any
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,6 +142,8 @@ using Base.Test, Nulls
     @test isequal(x, [null])
 
     @test Nulls.T(Union{Int, Null}) == Int
+    @test Nulls.T(Any) == Any
+    @test Nulls.T(Null) == Union{}
 
     @test isequal(nulls(1), [null])
     @test isequal(nulls(Int, 1), [null])
@@ -151,8 +153,6 @@ using Base.Test, Nulls
     @test Union{Int, Null}[1,2,3] == (Union{Int, Null})[1,2,3]
 
     @test convert(Union{Int, Null}, 1.0) == 1
-
-    @test Nulls.T(Any) == Any
 
     # AbstractArray{>:Null}
 


### PR DESCRIPTION
The absence of this definition triggers a test failure on Julia 0.7 (see https://github.com/JuliaData/Nulls.jl/pull/46).
The old behavior on Julia 0.6 (returning `Null`) was actually not correct.